### PR TITLE
fix: hide bottomsheet completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
 /.idea/appInsightsSettings.xml
+/.idea/deploymentTargetDropDown.xml
 .DS_Store
 /build
 /keystore.jks

--- a/feature/listacompra/src/main/java/com/z1/comparaprecos/feature/listacompra/presentation/screen/ListaCompraScreen.kt
+++ b/feature/listacompra/src/main/java/com/z1/comparaprecos/feature/listacompra/presentation/screen/ListaCompraScreen.kt
@@ -161,7 +161,7 @@ fun ListaCompraScreen(
     LaunchedEffect(key1 = uiEvent) {
         when (uiEvent) {
             is UiEvent.Inserted -> scope.launch {
-                scaffoldState.bottomSheetState.hide()
+                hideBottomSheet()
                 onEvent(
                     OnEvent.UpdateUiEvent(
                         UiEvent.ShowSnackbar(
@@ -173,7 +173,7 @@ fun ListaCompraScreen(
             }
 
             is UiEvent.Updated -> scope.launch {
-                scaffoldState.bottomSheetState.hide()
+                hideBottomSheet()
                 onEvent(
                     OnEvent.UpdateUiEvent(
                         UiEvent.ShowSnackbar(
@@ -185,7 +185,7 @@ fun ListaCompraScreen(
             }
 
             is UiEvent.Deleted -> scope.launch {
-                scaffoldState.bottomSheetState.hide()
+                hideBottomSheet()
                 onEvent(
                     OnEvent.UpdateUiEvent(
                         UiEvent.ShowSnackbar(


### PR DESCRIPTION
When keyboard and bottomSheet is closed in same time, part of bottomSheet stay visible on bottom of screen, add a delay to fix this bug.

I don't found the really cause, it's might be a jetpack compose bug.